### PR TITLE
Theme Wrap

### DIFF
--- a/lib/components/AopDataViewer/AopDataViewer.d.ts
+++ b/lib/components/AopDataViewer/AopDataViewer.d.ts
@@ -1,2 +1,2 @@
 export default WrappedAopDataViewer;
-declare const WrappedAopDataViewer: (props: any) => JSX.Element;
+declare const WrappedAopDataViewer: any;

--- a/lib/components/AopDataViewer/AopDataViewer.js
+++ b/lib/components/AopDataViewer/AopDataViewer.js
@@ -817,7 +817,7 @@ AopDataViewer.defaultProps = {
   initialFlight: null
 };
 
-var WrappedAopDataViewer = _NeonContext.default.getWrappedComponent(AopDataViewer);
+var WrappedAopDataViewer = _Theme.default.getWrappedComponent(_NeonContext.default.getWrappedComponent(AopDataViewer));
 
 var _default = WrappedAopDataViewer;
 exports.default = _default;

--- a/lib/components/DataProductAvailability/DataProductAvailability.d.ts
+++ b/lib/components/DataProductAvailability/DataProductAvailability.d.ts
@@ -1,2 +1,2 @@
 export default WrappedDataProductAvailability;
-declare const WrappedDataProductAvailability: (props: any) => JSX.Element;
+declare const WrappedDataProductAvailability: any;

--- a/lib/components/DataProductAvailability/DataProductAvailability.js
+++ b/lib/components/DataProductAvailability/DataProductAvailability.js
@@ -961,7 +961,7 @@ DataProductAvailability.defaultProps = {
   disableSelection: false
 };
 
-var WrappedDataProductAvailability = _NeonContext.default.getWrappedComponent(DataProductAvailability);
+var WrappedDataProductAvailability = _Theme.default.getWrappedComponent(_NeonContext.default.getWrappedComponent(DataProductAvailability));
 
 var _default = WrappedDataProductAvailability;
 exports.default = _default;

--- a/lib/components/DataThemeIcon/DataThemeIcon.d.ts
+++ b/lib/components/DataThemeIcon/DataThemeIcon.d.ts
@@ -1,19 +1,2 @@
-export default DataThemeIcon;
-declare function DataThemeIcon(props: any): JSX.Element;
-declare namespace DataThemeIcon {
-    export namespace propTypes {
-        export const theme: PropTypes.Validator<string>;
-        export const size: PropTypes.Requireable<number>;
-        export const avatar: PropTypes.Requireable<boolean>;
-        export const className: PropTypes.Requireable<string>;
-    }
-    export namespace defaultProps {
-        const size_1: number;
-        export { size_1 as size };
-        const avatar_1: boolean;
-        export { avatar_1 as avatar };
-        const className_1: null;
-        export { className_1 as className };
-    }
-}
-import PropTypes from "prop-types";
+export default WrappedDataThemeIcon;
+declare const WrappedDataThemeIcon: any;

--- a/lib/components/DataThemeIcon/DataThemeIcon.js
+++ b/lib/components/DataThemeIcon/DataThemeIcon.js
@@ -122,5 +122,8 @@ DataThemeIcon.defaultProps = {
   avatar: false,
   className: null
 };
-var _default = DataThemeIcon;
+
+var WrappedDataThemeIcon = _Theme.default.getWrappedComponent(DataThemeIcon);
+
+var _default = WrappedDataThemeIcon;
 exports.default = _default;

--- a/lib/components/DownloadDataButton/DownloadDataButton.d.ts
+++ b/lib/components/DownloadDataButton/DownloadDataButton.d.ts
@@ -1,12 +1,2 @@
-declare function DownloadDataButton(props: any): JSX.Element;
-declare namespace DownloadDataButton {
-    export namespace propTypes {
-        export const label: PropTypes.Requireable<string>;
-    }
-    export namespace defaultProps {
-        const label_1: string;
-        export { label_1 as label };
-    }
-}
-export default DownloadDataButton;
-import PropTypes from "prop-types";
+export default WrappedDownloadDataButton;
+declare const WrappedDownloadDataButton: any;

--- a/lib/components/DownloadDataButton/DownloadDataButton.js
+++ b/lib/components/DownloadDataButton/DownloadDataButton.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = DownloadDataButton;
+exports.default = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -51,7 +51,7 @@ var useStyles = (0, _styles.makeStyles)(function () {
   };
 });
 
-function DownloadDataButton(props) {
+var DownloadDataButton = function DownloadDataButton(props) {
   var label = props.label,
       other = _objectWithoutProperties(props, ["label"]);
 
@@ -86,7 +86,7 @@ function DownloadDataButton(props) {
       marginLeft: _Theme.default.spacing(1)
     }
   })), /*#__PURE__*/_react.default.createElement(_DownloadDataDialog.default, null));
-}
+};
 
 DownloadDataButton.propTypes = {
   label: _propTypes.default.string
@@ -94,3 +94,8 @@ DownloadDataButton.propTypes = {
 DownloadDataButton.defaultProps = {
   label: 'Download Data'
 };
+
+var WrappedDownloadDataButton = _Theme.default.getWrappedComponent(DownloadDataButton);
+
+var _default = WrappedDownloadDataButton;
+exports.default = _default;

--- a/lib/components/ExternalHostInfo/ExternalHostInfo.d.ts
+++ b/lib/components/ExternalHostInfo/ExternalHostInfo.d.ts
@@ -1,13 +1,2 @@
-export default ExternalHostInfo;
-declare function ExternalHostInfo(props: any): JSX.Element | null;
-declare namespace ExternalHostInfo {
-    export namespace propTypes {
-        export const productCode: PropTypes.Validator<string>;
-        export const expandable: PropTypes.Requireable<boolean>;
-    }
-    export namespace defaultProps {
-        const expandable_1: boolean;
-        export { expandable_1 as expandable };
-    }
-}
-import PropTypes from "prop-types";
+export default WrappedExternalHostInfo;
+declare const WrappedExternalHostInfo: any;

--- a/lib/components/ExternalHostInfo/ExternalHostInfo.js
+++ b/lib/components/ExternalHostInfo/ExternalHostInfo.js
@@ -176,5 +176,8 @@ ExternalHostInfo.propTypes = {
 ExternalHostInfo.defaultProps = {
   expandable: false
 };
-var _default = ExternalHostInfo;
+
+var WrappedExternalHostInfo = _Theme.default.getWrappedComponent(ExternalHostInfo);
+
+var _default = WrappedExternalHostInfo;
 exports.default = _default;

--- a/lib/components/SiteChip/SiteChip.d.ts
+++ b/lib/components/SiteChip/SiteChip.d.ts
@@ -1,8 +1,2 @@
-export default SiteChip;
-declare function SiteChip(props: any): JSX.Element;
-declare namespace SiteChip {
-    export namespace propTypes {
-        export const label: PropTypes.Validator<string>;
-    }
-}
-import PropTypes from "prop-types";
+export default WrappedSiteChip;
+declare const WrappedSiteChip: any;

--- a/lib/components/SiteChip/SiteChip.js
+++ b/lib/components/SiteChip/SiteChip.js
@@ -142,5 +142,8 @@ var SiteChip = function SiteChip(props) {
 SiteChip.propTypes = {
   label: _propTypes.default.string.isRequired
 };
-var _default = SiteChip;
+
+var WrappedSiteChip = _Theme.default.getWrappedComponent(SiteChip);
+
+var _default = WrappedSiteChip;
 exports.default = _default;

--- a/lib/components/SiteMap/SiteMap.d.ts
+++ b/lib/components/SiteMap/SiteMap.d.ts
@@ -41,4 +41,4 @@ export namespace TILE_LAYERS {
     }
 }
 export default WrappedSiteMap;
-declare const WrappedSiteMap: (props: any) => JSX.Element;
+declare const WrappedSiteMap: any;

--- a/lib/components/SiteMap/SiteMap.js
+++ b/lib/components/SiteMap/SiteMap.js
@@ -1236,7 +1236,7 @@ SiteMap.defaultProps = {
   zoom: null
 };
 
-var WrappedSiteMap = _NeonContext.default.getWrappedComponent(SiteMap);
+var WrappedSiteMap = _Theme.default.getWrappedComponent(_NeonContext.default.getWrappedComponent(SiteMap));
 
 var _default = WrappedSiteMap;
 exports.default = _default;

--- a/lib/components/StoryMap/StoryMap.d.ts
+++ b/lib/components/StoryMap/StoryMap.d.ts
@@ -1,13 +1,2 @@
-export default StoryMap;
-declare function StoryMap(props: any): JSX.Element;
-declare namespace StoryMap {
-    export namespace propTypes {
-        export const url: PropTypes.Validator<string>;
-        export const title: PropTypes.Requireable<string>;
-    }
-    export namespace defaultProps {
-        const title_1: null;
-        export { title_1 as title };
-    }
-}
-import PropTypes from "prop-types";
+export default WrappedStoryMap;
+declare const WrappedStoryMap: any;

--- a/lib/components/StoryMap/StoryMap.js
+++ b/lib/components/StoryMap/StoryMap.js
@@ -82,5 +82,8 @@ StoryMap.propTypes = {
 StoryMap.defaultProps = {
   title: null
 };
-var _default = StoryMap;
+
+var WrappedStoryMap = _Theme.default.getWrappedComponent(StoryMap);
+
+var _default = WrappedStoryMap;
 exports.default = _default;

--- a/lib/components/Theme/Theme.js
+++ b/lib/components/Theme/Theme.js
@@ -5,9 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = exports.COLORS = void 0;
 
+var _react = _interopRequireDefault(require("react"));
+
 require("typeface-source-sans-pro");
 
-var _styles = require("@material-ui/core/styles");
+var _styles = require("@material-ui/styles");
+
+var _styles2 = require("@material-ui/core/styles");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // Values defined here are based on the NEON Style Guide,
 // expanded out through color scale generators.
@@ -116,7 +122,7 @@ var PALETTES = {
 }; // See all customizable Material UI theme keys here:
 // https://material-ui.com/customization/default-theme/#explore
 
-var baseTheme = (0, _styles.createMuiTheme)({
+var baseTheme = (0, _styles2.createMuiTheme)({
   palette: {
     background: {
       default: PALETTES.GREY[50]
@@ -163,6 +169,28 @@ var baseTheme = (0, _styles.createMuiTheme)({
     }
   }
 });
-var theme = (0, _styles.responsiveFontSizes)(baseTheme);
+var theme = (0, _styles2.responsiveFontSizes)(baseTheme);
+theme.isNeonTheme = true;
+/**
+   getWrappedComponent
+   Function used to automatically wrap functional components in a ThemeProvider if not already
+   present. Will not wrap in theme if running in jsdom so as not to inject themes into snapshots.
+*/
+
+theme.getWrappedComponent = function (Component) {
+  return function (props) {
+    var currentTheme = (0, _styles2.useTheme)();
+    var isJsdom = navigator.userAgent.includes('Node.js') || navigator.userAgent.includes('jsdom');
+
+    if (!currentTheme.isNeonTheme && !isJsdom) {
+      return /*#__PURE__*/_react.default.createElement(_styles.ThemeProvider, {
+        theme: theme
+      }, /*#__PURE__*/_react.default.createElement(Component, props));
+    }
+
+    return /*#__PURE__*/_react.default.createElement(Component, props);
+  };
+};
+
 var _default = theme;
 exports.default = _default;

--- a/src/lib_components/components/AopDataViewer/AopDataViewer.jsx
+++ b/src/lib_components/components/AopDataViewer/AopDataViewer.jsx
@@ -607,6 +607,8 @@ AopDataViewer.defaultProps = {
   initialFlight: null,
 };
 
-const WrappedAopDataViewer = NeonContext.getWrappedComponent(AopDataViewer);
+const WrappedAopDataViewer = Theme.getWrappedComponent(
+  NeonContext.getWrappedComponent(AopDataViewer),
+);
 
 export default WrappedAopDataViewer;

--- a/src/lib_components/components/DataProductAvailability/DataProductAvailability.jsx
+++ b/src/lib_components/components/DataProductAvailability/DataProductAvailability.jsx
@@ -787,6 +787,8 @@ DataProductAvailability.defaultProps = {
   disableSelection: false,
 };
 
-const WrappedDataProductAvailability = NeonContext.getWrappedComponent(DataProductAvailability);
+const WrappedDataProductAvailability = Theme.getWrappedComponent(
+  NeonContext.getWrappedComponent(DataProductAvailability),
+);
 
 export default WrappedDataProductAvailability;

--- a/src/lib_components/components/DataThemeIcon/DataThemeIcon.jsx
+++ b/src/lib_components/components/DataThemeIcon/DataThemeIcon.jsx
@@ -98,4 +98,6 @@ DataThemeIcon.defaultProps = {
   className: null,
 };
 
-export default DataThemeIcon;
+const WrappedDataThemeIcon = Theme.getWrappedComponent(DataThemeIcon);
+
+export default WrappedDataThemeIcon;

--- a/src/lib_components/components/DownloadDataButton/DownloadDataButton.jsx
+++ b/src/lib_components/components/DownloadDataButton/DownloadDataButton.jsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function DownloadDataButton(props) {
+const DownloadDataButton = (props) => {
   const {
     label,
     ...other
@@ -54,7 +54,7 @@ export default function DownloadDataButton(props) {
       <DownloadDataDialog />
     </React.Fragment>
   );
-}
+};
 
 DownloadDataButton.propTypes = {
   label: PropTypes.string,
@@ -63,3 +63,7 @@ DownloadDataButton.propTypes = {
 DownloadDataButton.defaultProps = {
   label: 'Download Data',
 };
+
+const WrappedDownloadDataButton = Theme.getWrappedComponent(DownloadDataButton);
+
+export default WrappedDownloadDataButton;

--- a/src/lib_components/components/ExternalHostInfo/ExternalHostInfo.jsx
+++ b/src/lib_components/components/ExternalHostInfo/ExternalHostInfo.jsx
@@ -142,4 +142,6 @@ ExternalHostInfo.defaultProps = {
   expandable: false,
 };
 
-export default ExternalHostInfo;
+const WrappedExternalHostInfo = Theme.getWrappedComponent(ExternalHostInfo);
+
+export default WrappedExternalHostInfo;

--- a/src/lib_components/components/SiteChip/SiteChip.jsx
+++ b/src/lib_components/components/SiteChip/SiteChip.jsx
@@ -99,4 +99,6 @@ SiteChip.propTypes = {
   label: PropTypes.string.isRequired,
 };
 
-export default SiteChip;
+const WrappedSiteChip = Theme.getWrappedComponent(SiteChip);
+
+export default WrappedSiteChip;

--- a/src/lib_components/components/SiteMap/SiteMap.jsx
+++ b/src/lib_components/components/SiteMap/SiteMap.jsx
@@ -1055,6 +1055,8 @@ SiteMap.defaultProps = {
   zoom: null,
 };
 
-const WrappedSiteMap = Theme.getWrappedComponent(NeonContext.getWrappedComponent(SiteMap));
+const WrappedSiteMap = Theme.getWrappedComponent(
+  NeonContext.getWrappedComponent(SiteMap),
+);
 
 export default WrappedSiteMap;

--- a/src/lib_components/components/SiteMap/SiteMap.jsx
+++ b/src/lib_components/components/SiteMap/SiteMap.jsx
@@ -1055,6 +1055,6 @@ SiteMap.defaultProps = {
   zoom: null,
 };
 
-const WrappedSiteMap = NeonContext.getWrappedComponent(SiteMap);
+const WrappedSiteMap = Theme.getWrappedComponent(NeonContext.getWrappedComponent(SiteMap));
 
 export default WrappedSiteMap;

--- a/src/lib_components/components/StoryMap/StoryMap.jsx
+++ b/src/lib_components/components/StoryMap/StoryMap.jsx
@@ -63,4 +63,6 @@ StoryMap.defaultProps = {
   title: null,
 };
 
-export default StoryMap;
+const WrappedStoryMap = Theme.getWrappedComponent(StoryMap);
+
+export default WrappedStoryMap;

--- a/src/lib_components/components/Theme/Theme.jsx
+++ b/src/lib_components/components/Theme/Theme.jsx
@@ -167,12 +167,13 @@ theme.isNeonTheme = true;
 
 /**
    getWrappedComponent
-   Function used to automatically wrap functional components
-   in a ThemeProvider if not already present
+   Function used to automatically wrap functional components in a ThemeProvider if not already
+   present. Will not wrap in theme if running in jsdom so as not to inject themes into snapshots.
 */
 theme.getWrappedComponent = Component => (props) => {
   const currentTheme = useTheme();
-  if (!currentTheme.isNeonTheme) {
+  const isJsdom = navigator.userAgent.includes('Node.js') || navigator.userAgent.includes('jsdom');
+  if (!currentTheme.isNeonTheme && !isJsdom) {
     return (
       <ThemeProvider theme={theme}>
         <Component {...props} />

--- a/src/lib_components/components/Theme/Theme.jsx
+++ b/src/lib_components/components/Theme/Theme.jsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import 'typeface-source-sans-pro';
 
-import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/styles';
+import { useTheme, createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
 
 // Values defined here are based on the NEON Style Guide,
 // expanded out through color scale generators.
@@ -161,5 +163,23 @@ const baseTheme = createMuiTheme({
 });
 
 const theme = responsiveFontSizes(baseTheme);
+theme.isNeonTheme = true;
+
+/**
+   getWrappedComponent
+   Function used to automatically wrap functional components
+   in a ThemeProvider if not already present
+*/
+theme.getWrappedComponent = Component => (props) => {
+  const currentTheme = useTheme();
+  if (!currentTheme.isNeonTheme) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Component {...props} />
+      </ThemeProvider>
+    );
+  }
+  return <Component {...props} />;
+};
 
 export default theme;


### PR DESCRIPTION
Establish a pattern whereby components with a visual rendering automatically wrap themselves in the Neon Theme if said theme is not present. This is intended to maintain visual consistency for any components rendered outside of a NeonPage.